### PR TITLE
enable override embedparams for delivery request by options.params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ekolabs/eko-js-sdk",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "description": "A lightweight SDK that allows for easy integration of eko videos into webpages.",
     "main": "dist/EkoPlayer.min.js",
     "license": "Apache-2.0",

--- a/src/lib/ekoEmbed/v2.js
+++ b/src/lib/ekoEmbed/v2.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'eventemitter3';
 import ekoPlatform from '../ekoPlatform';
 import { stringifyQueryParams } from '../queryParamsUtils';
+import deepmerge from 'deepmerge';
 
 class EkoEmbedV2 {
     constructor(iframe) {
@@ -19,11 +20,13 @@ class EkoEmbedV2 {
 
 
     load(id, options) {
-        let embedParams = options.params || {};
-        embedParams.id = id;
-        embedParams.embedapi = '2.0';
-        embedParams.embedid = this.iframe.id;
-        embedParams.events = options.events.join(',');
+        let embedParams = {
+            id,
+            embedapi: '2.0',
+            embedid: this.iframe.id,
+            events: options.events.join(',')
+        };
+        embedParams = deepmerge.all([embedParams, options.params]);
 
         const clientSideParams = options.clientSideParams;
         if (clientSideParams && typeof clientSideParams === 'object') {

--- a/test/integration/ekoDelivery/v2.test.js
+++ b/test/integration/ekoDelivery/v2.test.js
@@ -325,7 +325,7 @@ describe('ekoPlayer.load()', () => {
     });
 
     it(`ekoPlayer.load(id, { params: { id: abcde, embedapi: 3.0 } })
-    check options params override defulat values and id args `, async() => {
+    check options params override default values and id args `, async() => {
         const page = await browser.newPage();
         await page.goto(`file://${__dirname}/../app.html?autoplay=false`);
 

--- a/test/integration/ekoDelivery/v2.test.js
+++ b/test/integration/ekoDelivery/v2.test.js
@@ -323,6 +323,43 @@ describe('ekoPlayer.load()', () => {
         });
         expect(cspFound).toBeTruthy();
     });
+
+    it(`ekoPlayer.load(id, { params: { id: abcde, embedapi: 3.0 } })
+    check options params override defulat values and id args `, async() => {
+        const page = await browser.newPage();
+        await page.goto(`file://${__dirname}/../app.html?autoplay=false`);
+
+        const overrideId = 'abcde';
+        const overrideEmbedapi = '3.0';
+
+        // Init EkoPlayer
+        await page.evaluate((id, api) => {
+            let ekoPlayer =  new EkoPlayer('#ekoPlayerEl', '2.0');
+            ekoPlayer.load('zmb330', {
+                params: {
+                    id: id,
+                    embedapi: api
+                }
+            });
+        }, overrideId, overrideEmbedapi);
+
+        // Get id query string value
+        const idValue = await page.evaluate(() => {
+            const iframeSrc = document.querySelector('iframe').getAttribute('src');
+            const iframeURL = new URL(iframeSrc);
+            return iframeURL.searchParams.get('id');
+        });
+
+        // Get embedapi string value
+        const embedapiValue = await page.evaluate(() => {
+            const iframeSrc = document.querySelector('iframe').getAttribute('src');
+            const iframeURL = new URL(iframeSrc);
+            return iframeURL.searchParams.get('embedapi');
+        });
+
+        expect(idValue).toEqual(overrideId);
+        expect(embedapiValue).toEqual(overrideEmbedapi);
+    });
 });
 
 describe('ekoPlayer.on()', () => {


### PR DESCRIPTION
- we need this change for Walmart pdp preview (walmart pdp static pages require id) and also
 we must supply "id" for ekoPlayer.load function call

so i added some logic to override the embed params(query string) passed to delivery service with options.params 